### PR TITLE
fix source path on windows

### DIFF
--- a/buildSrc/src/main/java/GolangBindTask.kt
+++ b/buildSrc/src/main/java/GolangBindTask.kt
@@ -161,7 +161,7 @@ open class GolangBindTask : DefaultTask() {
                     .asSequence()
                     .filter { line -> line.startsWith("replace") }
                     .map { replace ->
-                        replace.replace(REGEX_REPLACE_TARGET_LOCAL, "=> " + file.parentFile.absolutePath + "/")
+                        replace.replace(REGEX_REPLACE_TARGET_LOCAL, "=> " + file.parentFile.absolutePath.replace('\\','/') + "/")
                     }
                     .map { replace ->
                         replace.replace(REGEX_REPLACE_SOURCE_VERSION, " =>")


### PR DESCRIPTION
GolangBindTask#buildStubGoModule

生成 go.mod 内容时，Windows 的目录分隔符 \ 被转义，导致 build 失败

期望输出:
X:\Code\ClashForAndroid
实际输出:
X:CodeClashForAndroid