### PR TITLE
Fix profile receiver intent filter action name

### DIFF
--- a/service/src/main/AndroidManifest.xml
+++ b/service/src/main/AndroidManifest.xml
@@ -70,7 +70,7 @@
                 <action android:name="android.intent.action.TIMEZONE_CHANGED" />
             </intent-filter>
             <intent-filter>
-                <action android:name="{applicationId}.intent.action.PROFILE_REQUEST_UPDATE" />
+                <action android:name="${applicationId}.intent.action.REQUEST_UPDATE" />
                 <data android:scheme="uuid" />
             </intent-filter>
         </receiver>


### PR DESCRIPTION
理论上应该是这样，虽然不影响CFA自身发起的更新，不过外部调用的时候的action会不正确