### PR TITLE
Add Start & Stop shortcut

### DIFF
--- a/app/src/foss/res/xml/shortcuts.xml
+++ b/app/src/foss/res/xml/shortcuts.xml
@@ -1,0 +1,33 @@
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="StartProxyShortCut"
+        android:enabled="true"
+        android:icon="@drawable/ic_outline_check_circle_48"
+        android:shortcutShortLabel="@string/start_shortcut_short_label1"
+        android:shortcutLongLabel="@string/start_shortcut_long_label1"
+        android:shortcutDisabledMessage="@string/start_shortcut_disabled_message1">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.github.kr328.clash.foss"
+            android:targetClass="com.github.kr328.clash.ScStartProxyActivity" />
+        <!-- If your shortcut is associated with multiple intents, include them
+             here. The last intent in the list determines what the user sees when
+             they launch this shortcut. -->
+    </shortcut>
+    <!-- Specify more shortcuts here. -->
+    <shortcut
+        android:shortcutId="StopProxyShortCut"
+        android:enabled="true"
+        android:icon="@drawable/ic_outline_block_48"
+        android:shortcutShortLabel="@string/stop_shortcut_short_label1"
+        android:shortcutLongLabel="@string/stop_shortcut_long_label1"
+        android:shortcutDisabledMessage="@string/stop_shortcut_disabled_message1">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.github.kr328.clash.foss"
+            android:targetClass="com.github.kr328.clash.ScStopProxyActivity" />
+        <!-- If your shortcut is associated with multiple intents, include them
+             here. The last intent in the list determines what the user sees when
+             they launch this shortcut. -->
+    </shortcut>
+</shortcuts>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,6 +53,8 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
             </intent-filter>
+            <meta-data android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
         </activity>
         <activity
             android:name=".ExternalImportActivity"
@@ -151,7 +153,24 @@
             android:configChanges="uiMode"
             android:exported="false"
             android:label="@string/files" />
-
+        <activity
+            android:name=".ScStartProxyActivity"
+            android:exported="true"
+            android:configChanges="uiMode"
+            android:label="Switch" >
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".ScStopProxyActivity"
+            android:exported="true"
+            android:configChanges="uiMode"
+            android:label="Switch" >
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+            </intent-filter>
+        </activity>
         <service
             android:name=".LogcatService"
             android:exported="false"
@@ -166,7 +185,6 @@
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
         </service>
-
         <receiver
             android:name=".RestartReceiver"
             android:enabled="false"

--- a/app/src/main/java/com/github/kr328/clash/ScStartProxyActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/ScStartProxyActivity.kt
@@ -1,0 +1,28 @@
+package com.github.kr328.clash
+
+import android.os.Bundle
+import android.widget.Toast
+import com.github.kr328.clash.design.MainDesign
+import com.github.kr328.clash.util.startClashService
+
+class ScStartProxyActivity : BaseActivity<MainDesign>() {
+    override suspend fun main() {
+
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        moveTaskToBack(true)
+
+        if (!clashRunning)
+            startClashService()
+        else
+        {
+            val text = R.string.running
+            val duration = Toast.LENGTH_SHORT
+            val toast = Toast.makeText(applicationContext, text, duration)
+            toast.show()
+        }
+        finish()
+    }
+}

--- a/app/src/main/java/com/github/kr328/clash/ScStopProxyActivity.kt
+++ b/app/src/main/java/com/github/kr328/clash/ScStopProxyActivity.kt
@@ -1,0 +1,29 @@
+package com.github.kr328.clash
+
+import android.os.Bundle
+import android.widget.Toast
+import com.github.kr328.clash.design.MainDesign
+import com.github.kr328.clash.util.stopClashService
+
+class ScStopProxyActivity : BaseActivity<MainDesign>() {
+    override suspend fun main() {
+
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        moveTaskToBack(true)
+
+        if (clashRunning)
+            stopClashService()
+        else
+        {
+            val text = R.string.stopped
+            val duration = Toast.LENGTH_SHORT
+            val toast = Toast.makeText(applicationContext, text, duration)
+            toast.show()
+        }
+
+        finish()
+    }
+}

--- a/app/src/premium/res/xml/shortcuts.xml
+++ b/app/src/premium/res/xml/shortcuts.xml
@@ -1,0 +1,33 @@
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="StartProxyShortCut"
+        android:enabled="true"
+        android:icon="@drawable/ic_outline_check_circle_48"
+        android:shortcutShortLabel="@string/start_shortcut_short_label1"
+        android:shortcutLongLabel="@string/start_shortcut_long_label1"
+        android:shortcutDisabledMessage="@string/start_shortcut_disabled_message1">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.github.kr328.clash.premium"
+            android:targetClass="com.github.kr328.clash.ScStartProxyActivity" />
+        <!-- If your shortcut is associated with multiple intents, include them
+             here. The last intent in the list determines what the user sees when
+             they launch this shortcut. -->
+    </shortcut>
+    <!-- Specify more shortcuts here. -->
+    <shortcut
+        android:shortcutId="StopProxyShortCut"
+        android:enabled="true"
+        android:icon="@drawable/ic_outline_block_48"
+        android:shortcutShortLabel="@string/stop_shortcut_short_label1"
+        android:shortcutLongLabel="@string/stop_shortcut_long_label1"
+        android:shortcutDisabledMessage="@string/stop_shortcut_disabled_message1">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.github.kr328.clash.premium"
+            android:targetClass="com.github.kr328.clash.ScStopProxyActivity" />
+        <!-- If your shortcut is associated with multiple intents, include them
+             here. The last intent in the list determines what the user sees when
+             they launch this shortcut. -->
+    </shortcut>
+</shortcuts>

--- a/design/src/main/res/drawable/ic_outline_block_48.xml
+++ b/design/src/main/res/drawable/ic_outline_block_48.xml
@@ -1,0 +1,9 @@
+<vector android:height="48dp" android:viewportHeight="24"
+android:viewportWidth="24" android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+
+<path android:fillColor="#FFFFFF" android:pathData="M12,12m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0"/>
+
+<path android:fillColor="@android:color/black" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.42,0 -8,-3.58 -8,-8 0,-1.85 0.63,-3.55 1.69,-4.9L16.9,18.31C15.55,19.37 13.85,20 12,20zM18.31,16.9L7.1,5.69C8.45,4.63 10.15,4 12,4c4.42,0 8,3.58 8,8 0,1.85 -0.63,3.55 -1.69,4.9z"/>
+
+</vector>
+

--- a/design/src/main/res/drawable/ic_outline_check_circle_48.xml
+++ b/design/src/main/res/drawable/ic_outline_check_circle_48.xml
@@ -1,0 +1,9 @@
+<vector android:height="48dp" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <path android:fillColor="#FFFFFF" android:pathData="M12,12m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0"/>
+    <path android:fillColor="@android:color/black"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM16.59,7.58L10,14.17l-2.59,-2.58L6,13l4,4 8,-8z" />
+
+
+</vector>

--- a/design/src/main/res/values-zh-rHK/strings.xml
+++ b/design/src/main/res/values-zh-rHK/strings.xml
@@ -213,4 +213,10 @@
     <string name="name_server_policy">Name Server 策略</string>
     <string name="block_loopback">阻止本地迴環</string>
     <string name="block_loopback_summary">阻止本地迴環連接</string>
+    <string name="start_shortcut_short_label1">運行</string>
+    <string name="start_shortcut_long_label1">運行Clash</string>
+    <string name="start_shortcut_disabled_message1">無配置文件</string>
+    <string name="stop_shortcut_short_label1">停止</string>
+    <string name="stop_shortcut_long_label1">停止Clash</string>
+    <string name="stop_shortcut_disabled_message1">無配置文件</string>
 </resources>

--- a/design/src/main/res/values-zh-rTW/strings.xml
+++ b/design/src/main/res/values-zh-rTW/strings.xml
@@ -217,4 +217,10 @@
     <string name="allow_bypass">允許應用程式繞過</string>
     <string name="allow_bypass_summary">允許其他程式繞過 VPN</string>
     <string name="sniff_tls_sni">嗅探 TLS 的 SNI</string>
+    <string name="start_shortcut_short_label1">運行</string>
+    <string name="start_shortcut_long_label1">運行Clash</string>
+    <string name="start_shortcut_disabled_message1">無配置文件</string>
+    <string name="stop_shortcut_short_label1">停止</string>
+    <string name="stop_shortcut_long_label1">停止Clash</string>
+    <string name="stop_shortcut_disabled_message1">無配置文件</string>
 </resources>

--- a/design/src/main/res/values-zh/strings.xml
+++ b/design/src/main/res/values-zh/strings.xml
@@ -217,4 +217,10 @@
     <string name="allow_bypass">允许应用绕过</string>
     <string name="allow_bypass_summary">允许其他应用绕过 VPN</string>
     <string name="sniff_tls_sni">嗅探 TLS 的 SNI</string>
+    <string name="start_shortcut_short_label1">运行</string>
+    <string name="start_shortcut_long_label1">运行Clash</string>
+    <string name="start_shortcut_disabled_message1">无配置文件</string>
+    <string name="stop_shortcut_short_label1">停止</string>
+    <string name="stop_shortcut_long_label1">停止Clash</string>
+    <string name="stop_shortcut_disabled_message1">无配置文件</string>
 </resources>

--- a/design/src/main/res/values/strings.xml
+++ b/design/src/main/res/values/strings.xml
@@ -279,4 +279,10 @@
     <string name="version_updated_tips">The settings have been reseted and the old profiles needs to be saved again.</string>
 
     <string name="mode_switch_tips">Valid only for current session</string>
+    <string name="start_shortcut_short_label1">Start</string>
+    <string name="start_shortcut_long_label1">Start Clash</string>
+    <string name="start_shortcut_disabled_message1">No Config</string>
+    <string name="stop_shortcut_short_label1">Stop</string>
+    <string name="stop_shortcut_long_label1">Stop Clash</string>
+    <string name="stop_shortcut_disabled_message1">No Config</string>
 </resources>


### PR DESCRIPTION
Add Start & Stop shortcut, you can use it in Samsung One UI 's daily routine to automatically run Clash after connected to the specified Wifi, and automatically stop Clash after disconnected from specified Wifi.
增加长按桌面图标后出现的 运行/停止 快捷方式。